### PR TITLE
Add: typst version in CI

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -16,7 +16,9 @@ jobs:
         typ_file_name: [sample, sample-en]
     steps:
       - uses: actions/checkout@v4
-      - uses: typst-community/setup-typst@v3
+      - uses: typst-community/setup-typst@v4
+        with:
+          typst-version: 0.12.0
       - name: Install fonts
         run: |
           sudo apt-get update


### PR DESCRIPTION
2024年ではTypstのバージョンがv0.12.0であったため、CIを修正する。