### PR TITLE
参考文献引用番号の修正

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT No Attribution
 
-Copyright 2024 Shunsuke Kimura
+Copyright 2024, 2025 Shunsuke Kimura
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this
 software and associated documentation files (the "Software"), to deal in the Software

--- a/rengo.csl
+++ b/rengo.csl
@@ -14,7 +14,7 @@
     <category field="engineering"/>
     <category field="generic-base"/>
     <summary>第67回自動制御連合講演会フォーマット</summary>
-    <updated>2024-07-06T21:04:32+00:00</updated>
+    <updated>2025-06-29T21:04:32+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -140,12 +140,12 @@
     </date>
   </macro>
   <!-- End of Macros -->
-  <citation collapse="citation-number">
+  <citation>
     <sort>
       <key variable="citation-number"/>
     </sort>
-    <layout prefix="" suffix="" delimiter=", ">
-      <text variable="citation-number" prefix="[" suffix="]" />
+    <layout prefix="[" suffix="]" delimiter=", ">
+      <text variable="citation-number"/>
     </layout>
   </citation>
   <bibliography entry-spacing="0" second-field-align="flush">

--- a/sample-en.typ
+++ b/sample-en.typ
@@ -1,6 +1,6 @@
 // MIT No Attribution
-// Copyright 2024 Shunsuke Kimura
-// https://github.com/kimushun1101/rengo2024-typst
+// Copyright 2024, 2025 Shunsuke Kimura
+// https://github.com/kimushun1101/rengo-typst-template
 
 #import "lib-en.typ": rengo-en, definition, lemma, theorem, corollary, proof
 #show: rengo-en.with(
@@ -104,8 +104,7 @@ The ctheorems package is imported.
 = References
 References should appear in a separate bibliography at
 the end of the paper, with items referred to with numerals
-in square brackets @web @Conference @Journal. @Book
-// I have not found a way to cite references as [1, 2, 3] (2024.07.07)
+in square brackets @web @Conference @Journal.
 
 The following format is recommended for references:
 #set enum(numbering: "a)")
@@ -113,7 +112,7 @@ The following format is recommended for references:
 	$[$No.$]$ Authors: Paper title; \textit{Journal Title}, Vol.~volume, No.~number, pp.~first page--last page (year)
 + Conference papers\
 	$[$No.$]$ Authors: Paper title; \textit{Proceedings Title}, pp.~first page--last page (year)
-+ Books\
++ Books @Book\
 	$[$No.$]$ Authors: \textit{Book Title}, pp.~first page--last page, publisher (year)
 + Website\
 	$[$No.$]$ URL

--- a/sample.typ
+++ b/sample.typ
@@ -1,6 +1,6 @@
 // MIT No Attribution
-// Copyright 2024 Shunsuke Kimura
-// https://github.com/kimushun1101/rengo2024-typst
+// Copyright 2024, 2025 Shunsuke Kimura
+// https://github.com/kimushun1101/rengo-typst-template
 
 #import "lib.typ": rengo, definition, lemma, theorem, corollary, proof
 #show: rengo.with(
@@ -116,14 +116,13 @@ $ y(t) &= C x(t) + D u(t) $ <eq:output>
 = 参考文献
 文献の引用は本文中に @web @ConferenceJP @Journal のように書き，
 本文の最後にまとめて記述します．次のフォーマットを推奨します．
-@Book
-// 参考文献を [1, 2, 3] と表示する方法は今のところ見つけられていません(2024.07.07)
+
 #set enum(numbering: "a)")
 + 雑誌論文の場合\
 	$[$番号$]$ 著者：論文題目；雑誌名，Vol.~巻, No.~号, pp.~始ページ--終ページ (発行年)
 + 会議論文の場合\
 	$[$番号$]$ 著者：論文題目；会議論文誌名，pp.~始ページ--終ページ (発行年)
-+ 単行本の場合\
++ 単行本の場合 @Book\
 	$[$番号$]$ 著者：書名，pp.~始ページ--終ページ, 発行所 (発行年)
 + Websiteの場合\
 	$[$番号$]$ URL


### PR DESCRIPTION
参考文献を複数まとめて引用する場合に`[1, 2, 3]`のように表示されるように修正した。