### PR TITLE
Update jaconf-0.5.0

### DIFF
--- a/lib-en.typ
+++ b/lib-en.typ
@@ -1,7 +1,7 @@
 // MIT No Attribution
 // Copyright 2024, 2025 Shunsuke Kimura
 
-#import "@preview/jaconf:0.4.1": jaconf, appendix
+#import "@preview/jaconf:0.5.0": jaconf, appendix
 
 #let rengo-en(
   title: [sample],
@@ -15,9 +15,9 @@
 ) = {
   show: jaconf.with(
     // 基本 Basic
-    title-ja: title,
+    title: title,
     // title-en: title,
-    authors-ja: none,
+    authors: none,
     authors-en: authors,
     abstract: abstract,
     keywords: keywords,

--- a/lib.typ
+++ b/lib.typ
@@ -1,7 +1,7 @@
 // MIT No Attribution
 // Copyright 2024, 2025 Shunsuke Kimura
 
-#import "@preview/jaconf:0.4.1": jaconf, definition, lemma, theorem, corollary, proof, appendix
+#import "@preview/jaconf:0.5.0": jaconf, definition, lemma, theorem, corollary, proof, appendix
 
 #let rengo(
   title: [日本語タイトル],
@@ -17,9 +17,9 @@
 ) = {
   show: jaconf.with(
     // 基本 Basic
-    title-ja: title,
+    title: title,
     title-en: title-en,
-    authors-ja: authors,
+    authors: authors,
     authors-en: authors-en,
     abstract: abstract,
     keywords: keywords,


### PR DESCRIPTION
jaconf v0.5.0にアップグレードした。
これにより前付と本文の間のマージンが適切に調整できた。
アップグレードしたことにより、引数名が変更されたためこの対応も行った。